### PR TITLE
(tf-backend) Allow customizing state folder structure

### DIFF
--- a/modules/terraform-backend/gcs.tf
+++ b/modules/terraform-backend/gcs.tf
@@ -128,7 +128,7 @@ moved {
 
 resource "google_storage_managed_folder_iam_policy" "terraform_state" {
   for_each       = var.gcs_state_folders
-  bucket         = google_storage_managed_folder.terraform_state[each.key].bucket
-  managed_folder = google_storage_managed_folder.terraform_state[each.key].name
+  bucket         = google_storage_managed_folder.state[each.key].bucket
+  managed_folder = google_storage_managed_folder.state[each.key].name
   policy_data    = data.google_iam_policy.storage_folder_tfstate[each.key].policy_data
 }

--- a/modules/terraform-backend/gcs.tf
+++ b/modules/terraform-backend/gcs.tf
@@ -76,48 +76,59 @@ resource "google_storage_bucket_iam_policy" "policy" {
 
 # Managed folders and their permissions
 
-resource "google_storage_managed_folder" "terraform_state_prod" {
-  bucket = google_storage_bucket.tfstate.name
-  name   = "terraform/state/prod/"
+moved {
+  from = google_storage_managed_folder.terraform_state_prod
+  to   = google_storage_managed_folder.state["prod"]
 }
 
-resource "google_storage_managed_folder" "terraform_state_test" {
-  bucket = google_storage_bucket.tfstate.name
-  name   = "terraform/state/test/"
+moved {
+  from = google_storage_managed_folder.terraform_state_test
+  to   = google_storage_managed_folder.state["test"]
 }
 
-# IAM roles for cloud storage: https://cloud.google.com/storage/docs/access-control/iam-roles
-data "google_iam_policy" "storage_folder_tfstate_prod" {
-  binding {
-    role    = "roles/storage.admin"
-    members = var.iam_gcs_tfstate_folder_prod_admins
-  }
-  binding {
-    role    = "roles/storage.objectUser"
-    members = var.iam_gcs_tfstate_folder_prod_users
-  }
+resource "google_storage_managed_folder" "state" {
+  for_each = var.gcs_state_folders
+  bucket   = google_storage_bucket.tfstate.name
+  name     = "${var.gcs_state_base}/${each.key}/"
 }
 
 # IAM roles for cloud storage: https://cloud.google.com/storage/docs/access-control/iam-roles
-data "google_iam_policy" "storage_folder_tfstate_test" {
+
+moved {
+  from = data.google_iam_policy.storage_folder_tfstate_prod
+  to   = data.google_iam_policy.storage_folder_tfstate["prod"]
+}
+
+moved {
+  from = data.google_iam_policy.storage_folder_tfstate_test
+  to   = data.google_iam_policy.storage_folder_tfstate["test"]
+}
+
+data "google_iam_policy" "storage_folder_tfstate" {
+  for_each = var.gcs_state_folders
   binding {
     role    = "roles/storage.admin"
-    members = var.iam_gcs_tfstate_folder_test_admins
+    members = each.value.admins
   }
   binding {
     role    = "roles/storage.objectUser"
-    members = var.iam_gcs_tfstate_folder_test_users
+    members = each.value.users
   }
 }
 
-resource "google_storage_managed_folder_iam_policy" "terraform_state_prod" {
-  bucket         = google_storage_managed_folder.terraform_state_prod.bucket
-  managed_folder = google_storage_managed_folder.terraform_state_prod.name
-  policy_data    = data.google_iam_policy.storage_folder_tfstate_prod.policy_data
+moved {
+  from = google_storage_managed_folder_iam_policy.terraform_state_prod
+  to   = google_storage_managed_folder_iam_policy.terraform_state["prod"]
 }
 
-resource "google_storage_managed_folder_iam_policy" "terraform_state_test" {
-  bucket         = google_storage_managed_folder.terraform_state_test.bucket
-  managed_folder = google_storage_managed_folder.terraform_state_test.name
-  policy_data    = data.google_iam_policy.storage_folder_tfstate_test.policy_data
+moved {
+  from = google_storage_managed_folder_iam_policy.terraform_state_test
+  to   = google_storage_managed_folder_iam_policy.terraform_state["test"]
+}
+
+resource "google_storage_managed_folder_iam_policy" "terraform_state" {
+  for_each       = var.gcs_state_folders
+  bucket         = google_storage_managed_folder.terraform_state[each.key].bucket
+  managed_folder = google_storage_managed_folder.terraform_state[each.key].name
+  policy_data    = data.google_iam_policy.storage_folder_tfstate[each.key].policy_data
 }

--- a/modules/terraform-backend/variables.tf
+++ b/modules/terraform-backend/variables.tf
@@ -45,27 +45,31 @@ variable "iam_gcs_object_viewers" {
   type        = list(string)
 }
 
-variable "iam_gcs_tfstate_folder_prod_admins" {
-  description = "List of members to grant storage.admin role to on the 'prod' folder level"
-  type        = list(string)
-}
-
-variable "iam_gcs_tfstate_folder_prod_users" {
-  description = "List of members to grant storage.admin role to on the 'prod' folder level"
-  type        = list(string)
-}
-
-variable "iam_gcs_tfstate_folder_test_admins" {
-  description = "List of members to grant storage.admin role to on the 'test' folder level"
-  type        = list(string)
-}
-
-variable "iam_gcs_tfstate_folder_test_users" {
-  description = "List of members to grant storage.admin role to on the 'test' folder level"
-  type        = list(string)
-}
-
 # GCS
+
+variable "gcs_state_base" {
+  description = "Base path for storing state files"
+  type        = string
+  default     = "terraform/state"
+}
+
+variable "gcs_state_folders" {
+  description = "Map of folders and their admins/users members in ${gcs_state_base} to store state files in"
+  type = map(object({
+    admins = list(string)
+    users  = list(string)
+  }))
+  default = {
+    prod = {
+      admins = []
+      users  = []
+    }
+    test = {
+      admins = []
+      users  = []
+    },
+  }
+}
 
 variable "gcs_force_destroy" {
   description = "Whether to force destroy the bucket and all objects stored in it"

--- a/modules/terraform-backend/variables.tf
+++ b/modules/terraform-backend/variables.tf
@@ -54,7 +54,7 @@ variable "gcs_state_base" {
 }
 
 variable "gcs_state_folders" {
-  description = "Map of folders and their admins/users members in ${gcs_state_base} to store state files in"
+  description = "Map of folders and their admins/users members in $gcs_state_base to store state files in"
   type = map(object({
     admins = list(string)
     users  = list(string)


### PR DESCRIPTION
Having hardcoded state structure is far from ideal. This allows
users to customize it to their needs.

## Test Plan
n/a